### PR TITLE
Adds support for run once commands

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,7 @@ environment:
 
 build_script:
   - ps: dotnet build -c $env:BUILD_CONFIGURATION
-  - ps: dotnet test --results-directory $env:BUILD_ARTIFACT_PATH/test-results
+  - ps: dotnet test --results-directory $env:BUILD_ARTIFACT_PATH/test-results /p:SkipBuildVersioning=true
   - ps: dotnet pack --no-build -c $env:BUILD_CONFIGURATION /p:PackageOutputPath=$env:BUILD_ARTIFACT_PATH
   
 test: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Build
       run: dotnet build -c Release --no-restore
     - name: Test with Coverage
-      run: dotnet test --logger trx --results-directory ${{env.BUILD_ARTIFACT_PATH}}/coverage --collect "XPlat Code Coverage" --settings CodeCoverage.runsettings
+      run: dotnet test --logger trx --results-directory ${{env.BUILD_ARTIFACT_PATH}}/coverage --collect "XPlat Code Coverage" --settings CodeCoverage.runsettings /p:SkipBuildVersioning=true
     - name: Pack
       run: dotnet pack -c Release --no-build /p:PackageOutputPath=${{env.BUILD_ARTIFACT_PATH}}
     - name: Publish artifacts

--- a/TurnerSoftware.BuildVersioning.sln
+++ b/TurnerSoftware.BuildVersioning.sln
@@ -18,6 +18,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "global", "global", "{790239
 		.codecov.yml = .codecov.yml
 		.editorconfig = .editorconfig
 		.gitignore = .gitignore
+		azure-pipelines.yml = azure-pipelines.yml
 		CodeCoverage.runsettings = CodeCoverage.runsettings
 		License.txt = License.txt
 		README.md = README.md
@@ -28,7 +29,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{EC91FA7D
 		tests\Directory.Build.props = tests\Directory.Build.props
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TurnerSoftware.BuildVersioning.Tests", "tests\TurnerSoftware.BuildVersioning.Tests\TurnerSoftware.BuildVersioning.Tests.csproj", "{F97BCD71-3D0E-4B36-8BE5-B401A05E0829}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TurnerSoftware.BuildVersioning.Tests", "tests\TurnerSoftware.BuildVersioning.Tests\TurnerSoftware.BuildVersioning.Tests.csproj", "{F97BCD71-3D0E-4B36-8BE5-B401A05E0829}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ jobs:
     displayName: 'Build Application'
 
   - script: dotnet test /p:SkipBuildVersioning=true
-    displayName: 'Build Application'
+    displayName: 'Test Application'
        
   - script: dotnet pack --no-build -c $(BUILD_CONFIGURATION) /p:PackageOutputPath=$(BUILD_ARTIFACT_PATH)
     displayName: 'Pack Build'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,9 @@ jobs:
   steps:
   - script: dotnet build -c $(BUILD_CONFIGURATION)
     displayName: 'Build Application'
+
+  - script: dotnet test /p:SkipBuildVersioning=true
+    displayName: 'Build Application'
        
   - script: dotnet pack --no-build -c $(BUILD_CONFIGURATION) /p:PackageOutputPath=$(BUILD_ARTIFACT_PATH)
     displayName: 'Pack Build'

--- a/src/TurnerSoftware.BuildVersioning.Tool/TurnerSoftware.BuildVersioning.Tool.csproj
+++ b/src/TurnerSoftware.BuildVersioning.Tool/TurnerSoftware.BuildVersioning.Tool.csproj
@@ -8,8 +8,9 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <SelfHostedBuildVersioning Condition="'$(DesignTimeBuild)' != 'true' AND '$(SkipBuildVersioning)' != 'true'">true</SelfHostedBuildVersioning>
-    <BuildVersioningToolPath>../../TurnerSoftware.BuildVersioning.Tool/bin/$(Configuration)/$(TargetFramework)/TurnerSoftware.BuildVersioning.Tool.dll</BuildVersioningToolPath>
+    <BuildVersioningToolPath>bin/$(Configuration)/$(TargetFramework)/TurnerSoftware.BuildVersioning.Tool.dll</BuildVersioningToolPath>
+    <SelfHostedBuildVersioning Condition="$(DesignTimeBuild) != 'true' AND $(SkipBuildVersioning) != 'true' AND !Exists($(BuildVersioningToolPath))">true</SelfHostedBuildVersioning>
+    <BuildVersioningToolPath>../../TurnerSoftware.BuildVersioning.Tool/$(BuildVersioningToolPath)</BuildVersioningToolPath>
   </PropertyGroup>
   
   <ItemGroup>
@@ -18,9 +19,6 @@
 
   <!-- Self-hosting Support -->
   <Import Project="../TurnerSoftware.BuildVersioning/build/TurnerSoftware.BuildVersioning.targets" Condition="$(SelfHostedBuildVersioning) == 'true'" />
-  <PropertyGroup Condition="$(SelfHostedBuildVersioning) == 'true'">
-    <BuildVersioningToolPath>../../TurnerSoftware.BuildVersioning.Tool/bin/$(Configuration)/$(TargetFramework)/TurnerSoftware.BuildVersioning.Tool.dll</BuildVersioningToolPath>
-  </PropertyGroup>
   <Target Name="_SelfHostedBuildVersioning" BeforeTargets="BeforeBuild" Condition="$(SelfHostedBuildVersioning) == 'true'">
     <Message Importance="high" Text="BuildVersioning-SelfHosting: Establishing a baseline build to provide versioning support" />
     <Exec Command="dotnet build TurnerSoftware.BuildVersioning.Tool.csproj -c $(Configuration) -v quiet --nologo /p:SkipBuildVersioning=true" StandardOutputImportance="low"></Exec>

--- a/src/TurnerSoftware.BuildVersioning.Tool/TurnerSoftware.BuildVersioning.Tool.csproj
+++ b/src/TurnerSoftware.BuildVersioning.Tool/TurnerSoftware.BuildVersioning.Tool.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <BuildVersioningToolPath>bin/$(Configuration)/$(TargetFramework)/TurnerSoftware.BuildVersioning.Tool.dll</BuildVersioningToolPath>
-    <SelfHostedBuildVersioning Condition="$(DesignTimeBuild) != 'true' AND $(SkipBuildVersioning) != 'true' AND !Exists($(BuildVersioningToolPath))">true</SelfHostedBuildVersioning>
+    <SelfHostedBuildVersioning Condition="$(DesignTimeBuild) != 'true' AND $(SkipBuildVersioning) != 'true'">true</SelfHostedBuildVersioning>
     <BuildVersioningToolPath>../../TurnerSoftware.BuildVersioning.Tool/$(BuildVersioningToolPath)</BuildVersioningToolPath>
   </PropertyGroup>
   
@@ -19,7 +19,7 @@
 
   <!-- Self-hosting Support -->
   <Import Project="../TurnerSoftware.BuildVersioning/build/TurnerSoftware.BuildVersioning.targets" Condition="$(SelfHostedBuildVersioning) == 'true'" />
-  <Target Name="_SelfHostedBuildVersioning" BeforeTargets="BeforeBuild" Condition="$(SelfHostedBuildVersioning) == 'true'">
+  <Target Name="_SelfHostedBuildVersioning" BeforeTargets="BeforeBuild" Condition="$(SelfHostedBuildVersioning) == 'true' AND !Exists($(BuildVersioningToolPath))">
     <Message Importance="high" Text="BuildVersioning-SelfHosting: Establishing a baseline build to provide versioning support" />
     <Exec Command="dotnet build TurnerSoftware.BuildVersioning.Tool.csproj -c $(Configuration) -v quiet --nologo /p:SkipBuildVersioning=true" StandardOutputImportance="low"></Exec>
     <Message Importance="high" Text="BuildVersioning-SelfHosting: Baseline build has been completed" />

--- a/src/TurnerSoftware.BuildVersioning/build/TurnerSoftware.BuildVersioning.Integrations.targets
+++ b/src/TurnerSoftware.BuildVersioning/build/TurnerSoftware.BuildVersioning.Integrations.targets
@@ -10,7 +10,10 @@
     <BuildPreReleaseFormat Condition="$(GITHUB_REF.Split('/')[1]) == 'pull'">pr.$(GITHUB_REF.Split('/')[2])</BuildPreReleaseFormat>
     <BuildMetadataFormat>{CommitHash}-github.$(GITHUB_RUN_ID)</BuildMetadataFormat>
   </PropertyGroup>
-  <Target Name="_BuildVersioningWithGitHub" BeforeTargets="BeforeBuild" Condition="$(BuildVersioningWithGitHub) == 'true' AND $(GITHUB_RUN_ID) != ''">
+  <Target Name="_BuildVersioningWithGitHub" BeforeTargets="BeforeBuild" Condition="$(BuildVersioningWithGitHub) == 'true' AND $(GITHUB_RUN_ID) != '' AND !$(_BuildVersioningRunOne.Contains('github'))">
+    <PropertyGroup>
+      <_BuildVersioningRunOnce>$(_BuildVersioningRunOnce)github;</_BuildVersioningRunOnce>
+    </PropertyGroup>
     <Message Importance="$(BuildVersioningLogLevel)" Text="BuildVersioning-GitHubIntegration: Fetching tags for versioning as they aren't available by default in GitHub Actions" />
     <Exec Command="git fetch --prune --unshallow --tags --quiet" IgnoreExitCode="true" StandardErrorImportance="low" StandardOutputImportance="low" />
   </Target>
@@ -19,7 +22,10 @@
     <BuildPreReleaseFormat Condition="$(APPVEYOR_PULL_REQUEST_NUMBER) != ''">pr.$(APPVEYOR_PULL_REQUEST_NUMBER)</BuildPreReleaseFormat>
     <BuildMetadataFormat>{CommitHash}-appveyor.$(APPVEYOR_BUILD_ID)</BuildMetadataFormat>
   </PropertyGroup>
-  <Target Name="_BuildVersioningWithAppVeyor" AfterTargets="BuildVersioning" Condition="$(BuildVersioningWithAppVeyor) == 'true' AND $(APPVEYOR) != ''">
+  <Target Name="_BuildVersioningWithAppVeyor" AfterTargets="BuildVersioning" Condition="$(BuildVersioningWithAppVeyor) == 'true' AND $(APPVEYOR) != '' AND !$(_BuildVersioningRunOne.Contains('appveyor'))">
+    <PropertyGroup>
+      <_BuildVersioningRunOnce>$(_BuildVersioningRunOnce)appveyor;</_BuildVersioningRunOnce>
+    </PropertyGroup>
     <Message Importance="$(BuildVersioningLogLevel)" Text="BuildVersioning-AppVeyorIntegration: Updating AppVeyor build name to $(BuildFullVersion)" />
     <Exec Command="powershell Update-AppveyorBuild -Version $(BuildFullVersion)" />
   </Target>


### PR DESCRIPTION
Self-hosting of the tool now checks if it is already built. Integrations only need to be triggered once and while the state isn't saved per call to `dotnet`, this prevents it re-triggering for multiple projects in the solution.